### PR TITLE
go rewrite - switchover make command for pubsub/datafusion

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,6 +68,7 @@ mmv1:
 			bundle exec compiler.rb -e terraform -o $(OUTPUT_PATH) -v beta --no-code $(mmv1_compile); \
 		else \
 			bundle exec compiler.rb -e terraform -o $(OUTPUT_PATH) -v $(VERSION) $(mmv1_compile); \
+		go run . --version $(VERSION) --output $(OUTPUT_PATH); \
 		fi
 
 tpgtools:

--- a/mmv1/products/datafusion/Instance.yaml
+++ b/mmv1/products/datafusion/Instance.yaml
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Warning: This is a deprecated file, please edit the go_ version in the same
+# directory
+
 --- !ruby/object:Api::Resource
 name: 'Instance'
 base_url: 'projects/{{project}}/locations/{{region}}/instances'

--- a/mmv1/products/datafusion/go_Instance.yaml
+++ b/mmv1/products/datafusion/go_Instance.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Instance'
 description: |

--- a/mmv1/products/datafusion/go_product.yaml
+++ b/mmv1/products/datafusion/go_product.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'DataFusion'
 display_name: 'Cloud Data Fusion'

--- a/mmv1/products/datafusion/product.yaml
+++ b/mmv1/products/datafusion/product.yaml
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Warning: This is a deprecated file, please edit the go_ version in the same
+# directory
+
 --- !ruby/object:Api::Product
 name: DataFusion
 display_name: Cloud Data Fusion

--- a/mmv1/products/pubsub/Schema.yaml
+++ b/mmv1/products/pubsub/Schema.yaml
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Warning: This is a deprecated file, please edit the go_ version in the same
+# directory
+
 --- !ruby/object:Api::Resource
 name: 'Schema'
 description: |

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Warning: This is a deprecated file, please edit the go_ version in the same
+# directory
+
 --- !ruby/object:Api::Resource
 name: 'Subscription'
 description: |

--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Warning: This is a deprecated file, please edit the go_ version in the same
+# directory
+
 --- !ruby/object:Api::Resource
 name: 'Topic'
 description: |

--- a/mmv1/products/pubsub/go_Schema.yaml
+++ b/mmv1/products/pubsub/go_Schema.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Schema'
 description: |

--- a/mmv1/products/pubsub/go_Subscription.yaml
+++ b/mmv1/products/pubsub/go_Subscription.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Subscription'
 description: |

--- a/mmv1/products/pubsub/go_Topic.yaml
+++ b/mmv1/products/pubsub/go_Topic.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Topic'
 description: |

--- a/mmv1/products/pubsub/go_product.yaml
+++ b/mmv1/products/pubsub/go_product.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Pubsub'
 display_name: 'Cloud Pub/Sub'

--- a/mmv1/products/pubsub/product.yaml
+++ b/mmv1/products/pubsub/product.yaml
@@ -11,6 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Warning: This is a deprecated file, please edit the go_ version in the same
+# directory
+
 --- !ruby/object:Api::Product
 name: Pubsub
 display_name: Cloud Pub/Sub


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

runs the go engine directly after ruby engine for "mmv1" make command

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
